### PR TITLE
Add arm64 bazelisk build

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -447,6 +447,7 @@ repository = "bazelbuild/bazel-watcher"
 
 [[packages]]
 repository = "bazelbuild/bazelisk"
+platforms = { linux-64 = ["bazelisk-linux-amd64"], linux-aarch64 = ["bazelisk-linux-arm64"] }
 
 [[packages]]
 repository = "bazelbuild/buildtools"


### PR DESCRIPTION
As per the thread in the pixi discord: https://discord.com/channels/1082332781146800168/1473604501784236129/1473604501784236129

Just trying to get bazelisk with a build in conda via the github-releases channel for arm64 (besides the linux64)