### PR TITLE
Add platform specification for snyk_cli package

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4773,6 +4773,7 @@ repository = "smtg-ai/claude-squad"
 [[packages]]
 repository = "snyk/cli"
 name = "snyk_cli"
+platforms = { win-64 = "^snyk-win.exe$" }
 
 [[packages]]
 repository = "snyk/driftctl"


### PR DESCRIPTION
The snyk cli executable was named "snyk-win.exe". I hope this is the right way to make octoconda pick it up. 