### PR TITLE
Add vectordotdev/vector to packages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5579,6 +5579,9 @@ repository = "vektra/mockery"
 repository = "Versent/saml2aws"
 
 [[packages]]
+repository = "vectordotdev/vector"
+
+[[packages]]
 repository = "version-fox/vfox"
 
 [[packages]]


### PR DESCRIPTION
## Summary
- Adds [Vector](https://github.com/vectordotdev/vector) to the package list
- Vector is a high-performance observability data pipeline for collecting, transforming, and routing logs and metrics
- Release assets use standard Rust target triples (e.g. `vector-0.54.0-x86_64-unknown-linux-gnu.tar.gz`, `vector-0.54.0-arm64-apple-darwin.tar.gz`) so auto-detection should work out of the box