### PR TITLE
Add bundle package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,22 +62,24 @@ or more `[[packages]]` entries.
 
 ### `[conda]`
 
-| Key | Required | Description |
-|---|---|---|
-| `channel` | yes | Conda channel used to check for existing versions. Can be a short name (e.g. `github-releases`) or a full `https://prefix.dev/...` URL. |
-| `max-import-releases` | no | Maximum number of releases to import initially. Defaults to all releases releases. |
+| Key                   | Required | Description                                                                                                                             |
+| --------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `channel`             | yes      | Conda channel used to check for existing versions. Can be a short name (e.g. `github-releases`) or a full `https://prefix.dev/...` URL. |
+| `max-import-releases` | no       | Maximum number of releases to import initially. Defaults to all releases releases.                                                      |
 
 ### `[[packages]]`
 
 Each `[[packages]]` entry describes a GitHub repository whose releases should
 be packaged.
 
-| Key | Required | Description |
-|---|---|---|
-| `repository` | yes | GitHub repository in `owner/repo` format. |
-| `name` | no | Package name used in the Conda channel. Defaults to the repository name (the part after `/`). |
-| `release-prefix` | no | Expected prefix of release binary filenames. Defaults to the package name. Set to `""` to disable prefix matching. |
-| `platforms` | no | Override the default platform detection patterns. See [Platform Patterns](#platform-patterns) below. |
+| Key              | Required | Description                                                                                                                                                                                                                                                                                         |
+| ---------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repository`     | yes      | GitHub repository in `owner/repo` format.                                                                                                                                                                                                                                                           |
+| `name`           | no       | Package name used in the Conda channel. Defaults to the repository name (the part after `/`).                                                                                                                                                                                                       |
+| `release-prefix` | no       | Expected prefix of release binary filenames. Defaults to the package name. Set to `""` to disable prefix matching.                                                                                                                                                                                  |
+| `tag-prefix`     | no       | Custom prefix to strip from release tags before version parsing. When set, only tags starting with this prefix are considered and the prefix is removed to extract the version.                                                                                                                     |
+| `platforms`      | no       | Override the default platform detection patterns. See [Platform Patterns](#platform-patterns) below.                                                                                                                                                                                                |
+| `expose`         | no       | List of extra top-level directory names to preserve in the conda package. By default only standard conda directories (`bin/`, `lib/`, `include/`, `share/`, `etc/`, `ssl/`) are kept; everything else is moved to `extras/`. Use for packages like JDKs that ship additional directories (e.g. `["conf", "jmods"]`). |
 
 ### Minimal Example
 
@@ -135,7 +137,7 @@ repository = "owner/repo"
 platforms = { linux-64 = ["my-custom-regex-.*linux"] }
 ```
 
-**Replace with a single regex** (when `name` is *not* set):
+**Replace with a single regex** (when `name` is _not_ set):
 
 ```toml
 [[packages]]
@@ -143,7 +145,7 @@ repository = "owner/repo"
 platforms = { linux-64 = "my-custom-regex-.*linux" }
 ```
 
-**Prepend the package name** to default patterns (when `name` *is* set).
+**Prepend the package name** to default patterns (when `name` _is_ set).
 Providing a plain string while `name` is set prepends `<name>.*` to each
 default pattern for that platform, effectively narrowing matching to assets
 that start with the package name:
@@ -157,10 +159,10 @@ platforms = { linux-64 = "" }
 
 ## Environment Variables
 
-| Variable | Description |
-|---|---|
-| `GITHUB_TOKEN` | Personal access token for GitHub API authentication (preferred). |
-| `GITHUB_ACCESS_TOKEN` | Alternative user access token for GitHub API authentication. |
+| Variable              | Description                                                      |
+| --------------------- | ---------------------------------------------------------------- |
+| `GITHUB_TOKEN`        | Personal access token for GitHub API authentication (preferred). |
+| `GITHUB_ACCESS_TOKEN` | Alternative user access token for GitHub API authentication.     |
 
 Without either token, API calls are made anonymously and subject to GitHub's
 unauthenticated rate limit (~60 requests/hour).

--- a/config.toml
+++ b/config.toml
@@ -2121,6 +2121,13 @@ name = "gotify_cli"
 repository = "gptscript-ai/gptscript"
 
 [[packages]]
+repository = "graalvm/graalvm-ce-builds"
+name = "graalvm"
+release-prefix = "graalvm-community-jdk"
+tag-prefix = "jdk-"
+expose = ["conf", "jmods"]
+
+[[packages]]
 repository = "gradle/gradle-distributions"
 
 [[packages]]

--- a/config.toml
+++ b/config.toml
@@ -4592,6 +4592,9 @@ repository = "sachaos/toggl"
 repository = "sachaos/viddy"
 
 [[packages]]
+repository = "SagerNet/sing-box"
+
+[[packages]]
 repository = "sacloud/usacloud"
 
 [[packages]]

--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,7 @@
 authors = ["Tobias Hunger <tobias.hunger@gmail.com>"]
 channels = ["conda-forge"]
 name = "octoconda"
-platforms = ["linux-64"]
+platforms = ["linux-64", "linux-aarch64"]
 version = "0.1.0"
 
 [tasks]
@@ -11,6 +11,7 @@ rebalance-repos = { cmd = "python scripts/rebalance_repos.py" }
 build-one = { cmd = "bash scripts/build_one.sh" }
 
 [dependencies]
+7zip = "*"
 actionlint = "*"
 zizmor = "*"
 rattler-build = "*"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,30 +25,12 @@ while [ "$STEP" -lt "$MAX_STEPS" ]; do
     FILE_TYPE=$(file -b "$SRC_FILE")
     echo "Step ${STEP}: ${FILE_TYPE}"
     case "$FILE_TYPE" in
-        *Zip\ archive* | *zip\ archive*)
-            ( cd "$PREFIX" && unzip -n "$SRC_FILE" )
-            # Delete extra stuff Macs apparently stuffed into zip files:
-            rm -rf "$PREFIX/__MACOSX" || true
+        *Zip\ archive* | *zip\ archive* | *tar\ archive* | *7-zip\ archive*)
+            ( cd "$PREFIX" && 7zz x -y -snld -xr!__MACOSX "$SRC_FILE" )
             break
             ;;
-        *tar\ archive*)
-            ( cd "$PREFIX" && tar -xf "$SRC_FILE" )
-            break
-            ;;
-        *gzip\ compressed*)
-            gzip -dc < "$SRC_FILE" > "${SRC_FILE}.tmp"
-            mv "${SRC_FILE}.tmp" "$SRC_FILE"
-            ;;
-        *XZ\ compressed*)
-            xz -dc < "$SRC_FILE" > "${SRC_FILE}.tmp"
-            mv "${SRC_FILE}.tmp" "$SRC_FILE"
-            ;;
-        *Zstandard\ compressed* | *zstd\ compressed*)
-            zstd -dc < "$SRC_FILE" > "${SRC_FILE}.tmp"
-            mv "${SRC_FILE}.tmp" "$SRC_FILE"
-            ;;
-        *bzip2\ compressed*)
-            bzip2 -dc < "$SRC_FILE" > "${SRC_FILE}.tmp"
+        *gzip\ compressed* | *XZ\ compressed* | *Zstandard\ compressed* | *zstd\ compressed* | *bzip2\ compressed*)
+            7zz e -so -snld "$SRC_FILE" > "${SRC_FILE}.tmp"
             mv "${SRC_FILE}.tmp" "$SRC_FILE"
             ;;
         *PE32+* | *PE32*)
@@ -80,6 +62,20 @@ shopt -s dotglob
 while [ "$(find . -mindepth 1 -maxdepth 1 -type d -not -name conda-meta | wc -l)" -eq 1 ]; do
     if test -d "bin"; then
         echo "Found only a bin subdir, this looks good"
+        break
+    elif [ -d "Contents/Home" ]; then
+        # macOS .app bundle: extract Contents/Home directly
+        TMPNAME=".strip-$$"
+        mv "Contents/Home" "${TMPNAME}"
+        mv "${TMPNAME}"/* . || true
+        rmdir "${TMPNAME}"
+        break
+    elif [ -d "Contents/MacOS" ]; then
+        # macOS .app bundle (no Home): extract Contents/MacOS directly
+        TMPNAME=".strip-$$"
+        mv "Contents/MacOS" "${TMPNAME}"
+        mv "${TMPNAME}"/* . || true
+        rmdir "${TMPNAME}"
         break
     else
         # move everything up a level, using a temp name to avoid
@@ -147,7 +143,11 @@ for f in *; do
         conda-meta|bin|etc|include|lib|share|ssl|extras)
             ;;
         *)
-            mv "${f}" extras
+            if [ -n "${OCTOCONDA_EXPOSE:-}" ] && echo "|${OCTOCONDA_EXPOSE}|" | grep -q "|${f}|"; then
+                :
+            else
+                mv "${f}" extras
+            fi
         esac
     fi
 done

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -32,7 +32,11 @@ pub struct TomlSubPackage {
     pub name: String,
     #[serde(rename = "release-prefix")]
     pub release_prefix: Option<String>,
+    #[serde(rename = "tag-prefix")]
+    pub tag_prefix: Option<String>,
     pub platforms: Option<HashMap<Platform, StringOrList>>,
+    #[serde(default)]
+    pub expose: Option<Vec<String>>,
 }
 
 #[derive(Deserialize)]
@@ -40,11 +44,15 @@ pub struct TomlPackage {
     pub name: Option<String>,
     #[serde(rename = "release-prefix")]
     pub release_prefix: Option<String>,
+    #[serde(rename = "tag-prefix")]
+    pub tag_prefix: Option<String>,
     pub repository: String,
     pub platforms: Option<HashMap<Platform, StringOrList>>,
     #[serde(default)]
     pub deprecated: bool,
     pub packages: Option<Vec<TomlSubPackage>>,
+    #[serde(default)]
+    pub expose: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug)]
@@ -52,7 +60,9 @@ pub struct Package {
     pub name: String,
     pub repository: Repository,
     release_prefix: Option<String>,
+    pub tag_prefix: Option<String>,
     platform_pattern: HashMap<Platform, Vec<String>>,
+    pub expose: Vec<String>,
 }
 
 impl Package {
@@ -97,7 +107,7 @@ const WINDOWS: &str = "(windows|win(32|64)?)";
 fn default_platforms() -> HashMap<Platform, Vec<String>> {
     fn linux_patterns(arch: &str, width: usize) -> Vec<String> {
         let linux = format!("linux({width})?");
-        let extra = format!("([._-]({VERSION}|x11|unknown|gh))*");
+        let extra = format!("([._-]({VERSION}|x11|unknown|gh|bin))*");
         let gnu = "gnu|glibc\\d*";
         let mut result = vec![
             format!(
@@ -126,7 +136,7 @@ fn default_platforms() -> HashMap<Platform, Vec<String>> {
     }
 
     fn mac_patterns(arch: &str) -> Vec<String> {
-        let extra = format!("([._-]({VERSION}|unknown|gh))*");
+        let extra = format!("([._-]({VERSION}|unknown|gh|bin))*");
         vec![
             format!("{arch}([\\._-]apple)?[\\._-]{APPLE}-15{extra}({COMPRESSED}|{ARCHIVE})?$"),
             format!("{APPLE}-15[\\._-]{arch}{extra}({COMPRESSED}|{ARCHIVE})?$"),
@@ -151,7 +161,7 @@ fn default_platforms() -> HashMap<Platform, Vec<String>> {
             format!(
                 "{arch}([\\._-]pc)?[\\._-]{WINDOWS}([\\._-]msvc)?{VER}([\\._-]exe)?({ARCHIVE}|\\.exe)?$"
             ),
-            format!("{WINDOWS}([\\._-]msvc)?[\\._-]{arch}{VER}([\\._-]exe)?({ARCHIVE}|\\.exe)?$"),
+            format!("{WINDOWS}([\\._-]msvc)?[\\._-]{arch}{VER}([\\._-]bin)?([\\._-]exe)?({ARCHIVE}|\\.exe)?$"),
             format!(
                 "{arch}([\\._-]pc)?[\\._-]{WINDOWS}[\\._-]gnu(llvm)?{VER}([\\._-]exe)?({ARCHIVE}|\\.exe)?$"
             ),
@@ -211,10 +221,10 @@ fn expand_toml_package(value: TomlPackage) -> anyhow::Result<Vec<Package>> {
     let repository = Repository::try_from(value.repository.as_str())?;
 
     if let Some(sub_packages) = value.packages {
-        if value.name.is_some() || value.release_prefix.is_some() {
+        if value.name.is_some() || value.release_prefix.is_some() || value.tag_prefix.is_some() {
             anyhow::bail!(
-                "Repository \"{}\": top-level \"name\" and \"release-prefix\" \
-                 cannot be combined with a \"packages\" list",
+                "Repository \"{}\": top-level \"name\", \"release-prefix\", \
+                 and \"tag-prefix\" cannot be combined with a \"packages\" list",
                 value.repository,
             );
         }
@@ -241,7 +251,9 @@ fn expand_toml_package(value: TomlPackage) -> anyhow::Result<Vec<Package>> {
                     name,
                     repository: repository.clone(),
                     release_prefix: sp.release_prefix,
+                    tag_prefix: sp.tag_prefix,
                     platform_pattern: resolve_platforms(sp.platforms),
+                    expose: sp.expose.unwrap_or_default(),
                 })
             })
             .collect()
@@ -251,7 +263,9 @@ fn expand_toml_package(value: TomlPackage) -> anyhow::Result<Vec<Package>> {
             name,
             repository,
             release_prefix: value.release_prefix,
+            tag_prefix: value.tag_prefix,
             platform_pattern: resolve_platforms(value.platforms),
+            expose: value.expose.unwrap_or_default(),
         }])
     }
 }
@@ -398,10 +412,12 @@ pub mod tests {
         let toml = TomlPackage {
             name: None,
             release_prefix: rp,
+            tag_prefix: None,
             repository: "foo/bar".to_string(),
             platforms: None,
             deprecated: false,
             packages: None,
+            expose: None,
         };
         let mut packages = expand_toml_package(toml).unwrap();
         packages.remove(0).platform_pattern().unwrap()
@@ -423,18 +439,22 @@ pub mod tests {
             TomlPackage {
                 name: None,
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "alice/foo".to_string(),
                 platforms: None,
                 deprecated: false,
                 packages: None,
+                expose: None,
             },
             TomlPackage {
                 name: None,
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "bob/foo".to_string(),
                 platforms: None,
                 deprecated: false,
                 packages: None,
+                expose: None,
             },
         ]);
         let err = Config::try_from(config).unwrap_err();
@@ -450,18 +470,22 @@ pub mod tests {
             TomlPackage {
                 name: Some("Foo".to_string()),
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "alice/something".to_string(),
                 platforms: None,
                 deprecated: false,
                 packages: None,
+                expose: None,
             },
             TomlPackage {
                 name: Some("foo".to_string()),
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "bob/other".to_string(),
                 platforms: None,
                 deprecated: false,
                 packages: None,
+                expose: None,
             },
         ]);
         let err = Config::try_from(config).unwrap_err();
@@ -477,18 +501,22 @@ pub mod tests {
             TomlPackage {
                 name: None,
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "alice/foo".to_string(),
                 platforms: None,
                 deprecated: false,
                 packages: None,
+                expose: None,
             },
             TomlPackage {
                 name: Some("foo".to_string()),
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "bob/bar".to_string(),
                 platforms: None,
                 deprecated: false,
                 packages: None,
+                expose: None,
             },
         ]);
         let err = Config::try_from(config).unwrap_err();
@@ -504,18 +532,22 @@ pub mod tests {
             TomlPackage {
                 name: None,
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "alice/foo".to_string(),
                 platforms: None,
                 deprecated: false,
                 packages: None,
+                expose: None,
             },
             TomlPackage {
                 name: None,
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "bob/bar".to_string(),
                 platforms: None,
                 deprecated: false,
                 packages: None,
+                expose: None,
             },
         ]);
         Config::try_from(config).unwrap();
@@ -527,18 +559,22 @@ pub mod tests {
             TomlPackage {
                 name: None,
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "alice/foo".to_string(),
                 platforms: None,
                 deprecated: true,
                 packages: None,
+                expose: None,
             },
             TomlPackage {
                 name: None,
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "bob/foo".to_string(),
                 platforms: None,
                 deprecated: false,
                 packages: None,
+                expose: None,
             },
         ]);
         let cfg = Config::try_from(config).unwrap();
@@ -552,18 +588,22 @@ pub mod tests {
             TomlPackage {
                 name: None,
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "alice/foo".to_string(),
                 platforms: None,
                 deprecated: true,
                 packages: None,
+                expose: None,
             },
             TomlPackage {
                 name: None,
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "bob/foo".to_string(),
                 platforms: None,
                 deprecated: true,
                 packages: None,
+                expose: None,
             },
         ]);
         let cfg = Config::try_from(config).unwrap();
@@ -575,6 +615,7 @@ pub mod tests {
         let config = toml_config(vec![TomlPackage {
             name: None,
             release_prefix: None,
+            tag_prefix: None,
             repository: "oxc-project/oxc".to_string(),
             platforms: None,
             deprecated: false,
@@ -582,14 +623,20 @@ pub mod tests {
                 TomlSubPackage {
                     name: "oxfmt".to_string(),
                     release_prefix: Some("oxfmt".to_string()),
+                    tag_prefix: None,
                     platforms: None,
+                    expose: None,
                 },
                 TomlSubPackage {
                     name: "oxlint".to_string(),
                     release_prefix: Some("oxlint".to_string()),
+                    tag_prefix: None,
                     platforms: None,
+                    expose: None,
                 },
             ]),
+
+            expose: None,
         }]);
         let cfg = Config::try_from(config).unwrap();
         assert_eq!(cfg.packages.len(), 2);
@@ -604,14 +651,19 @@ pub mod tests {
         let config = toml_config(vec![TomlPackage {
             name: Some("bad".to_string()),
             release_prefix: None,
+            tag_prefix: None,
             repository: "owner/repo".to_string(),
             platforms: None,
             deprecated: false,
             packages: Some(vec![TomlSubPackage {
                 name: "pkg".to_string(),
                 release_prefix: None,
+                tag_prefix: None,
                 platforms: None,
+                expose: None,
             }]),
+
+            expose: None,
         }]);
         let err = Config::try_from(config).unwrap_err();
         assert!(
@@ -626,22 +678,29 @@ pub mod tests {
             TomlPackage {
                 name: None,
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "alice/foo".to_string(),
                 platforms: None,
                 deprecated: false,
                 packages: None,
+                expose: None,
             },
             TomlPackage {
                 name: None,
                 release_prefix: None,
+                tag_prefix: None,
                 repository: "oxc-project/oxc".to_string(),
                 platforms: None,
                 deprecated: false,
                 packages: Some(vec![TomlSubPackage {
                     name: "foo".to_string(),
                     release_prefix: None,
+                    tag_prefix: None,
                     platforms: None,
+                    expose: None,
                 }]),
+
+                expose: None,
             },
         ]);
         let err = Config::try_from(config).unwrap_err();
@@ -649,5 +708,41 @@ pub mod tests {
             err.to_string().contains("Duplicate package name"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn test_expose_dirs_parses() {
+        let config = toml_config(vec![TomlPackage {
+            name: Some("graalvm".to_string()),
+            release_prefix: None,
+            tag_prefix: None,
+            repository: "graalvm/graalvm-ce-builds".to_string(),
+            platforms: None,
+            deprecated: false,
+            packages: None,
+            expose: Some(vec!["conf".to_string(), "jmods".to_string()]),
+        }]);
+        let cfg = Config::try_from(config).unwrap();
+        assert_eq!(cfg.packages.len(), 1);
+        assert_eq!(
+            cfg.packages[0].expose,
+            vec!["conf".to_string(), "jmods".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_expose_standalone_accepted() {
+        let config = toml_config(vec![TomlPackage {
+            name: Some("mypkg".to_string()),
+            release_prefix: None,
+            tag_prefix: None,
+            repository: "owner/repo".to_string(),
+            platforms: None,
+            deprecated: false,
+            packages: None,
+            expose: Some(vec!["conf".to_string()]),
+        }]);
+        let cfg = Config::try_from(config).unwrap();
+        assert_eq!(cfg.packages[0].expose, vec!["conf".to_string()]);
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -87,6 +87,7 @@ impl Github {
 pub fn filter_releases_for_package(
     releases: &[octocrab::models::repos::Release],
     package_name: &str,
+    tag_prefix: Option<&str>,
     max_import_releases: usize,
 ) -> Vec<(octocrab::models::repos::Release, (String, u32))> {
     use std::collections::HashSet;
@@ -97,7 +98,12 @@ pub fn filter_releases_for_package(
     for release in releases {
         let tag = &release.tag_name;
 
-        let tag = if let Some(t) = tag
+        let tag = if let Some(prefix) = tag_prefix {
+            match tag.strip_prefix(prefix) {
+                Some(t) => t.to_string(),
+                None => continue,
+            }
+        } else if let Some(t) = tag
             .strip_prefix(&format!("{package_name}_"))
             .or_else(|| tag.strip_prefix(&format!("{package_name}-")))
         {
@@ -165,7 +171,7 @@ mod tests {
     fn parses_hyphenated_package_prefix() {
         // oven-sh/bun tags look like `bun-v1.3.13`.
         let releases = vec![release_with_tag("bun-v1.3.13")];
-        let result = filter_releases_for_package(&releases, "bun", 10);
+        let result = filter_releases_for_package(&releases, "bun", None, 10);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].1, ("1.3.13".to_string(), 0));
     }
@@ -173,7 +179,7 @@ mod tests {
     #[test]
     fn parses_underscored_package_prefix() {
         let releases = vec![release_with_tag("foo_v2.0.0")];
-        let result = filter_releases_for_package(&releases, "foo", 10);
+        let result = filter_releases_for_package(&releases, "foo", None, 10);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].1, ("2.0.0".to_string(), 0));
     }
@@ -181,7 +187,7 @@ mod tests {
     #[test]
     fn parses_bare_v_prefix() {
         let releases = vec![release_with_tag("v0.1.2")];
-        let result = filter_releases_for_package(&releases, "whatever", 10);
+        let result = filter_releases_for_package(&releases, "whatever", None, 10);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].1, ("0.1.2".to_string(), 0));
     }
@@ -189,7 +195,7 @@ mod tests {
     #[test]
     fn parses_build_suffix() {
         let releases = vec![release_with_tag("v1.2.3-4")];
-        let result = filter_releases_for_package(&releases, "pkg", 10);
+        let result = filter_releases_for_package(&releases, "pkg", None, 10);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].1, ("1.2.3".to_string(), 4));
     }
@@ -197,7 +203,30 @@ mod tests {
     #[test]
     fn rejects_non_version_tag() {
         let releases = vec![release_with_tag("nightly")];
-        let result = filter_releases_for_package(&releases, "pkg", 10);
+        let result = filter_releases_for_package(&releases, "pkg", None, 10);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn custom_tag_prefix_strips_and_parses() {
+        let releases = vec![
+            release_with_tag("jdk-25.0.2"),
+            release_with_tag("jdk-23.0.2"),
+        ];
+        let result = filter_releases_for_package(&releases, "graalvm", Some("jdk-"), 10);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].1, ("25.0.2".to_string(), 0));
+        assert_eq!(result[1].1, ("23.0.2".to_string(), 0));
+    }
+
+    #[test]
+    fn custom_tag_prefix_skips_non_matching_tags() {
+        let releases = vec![
+            release_with_tag("jdk-25.0.2"),
+            release_with_tag("vm-22.3.3"),
+        ];
+        let result = filter_releases_for_package(&releases, "graalvm", Some("jdk-"), 10);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].1, ("25.0.2".to_string(), 0));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,6 +186,7 @@ fn main() -> Result<(), anyhow::Error> {
                             let releases = github::filter_releases_for_package(
                                 &raw_releases,
                                 &package.name,
+                                package.tag_prefix.as_deref(),
                                 max_releases,
                             );
 

--- a/src/package_generation.rs
+++ b/src/package_generation.rs
@@ -646,13 +646,14 @@ about:
 
 fn generate_rattler_build_recipe(
     work_dir: &Path,
-    package_name: &str,
+    package: &Package,
     package_version: &str,
     build_number: u32,
     target_platform: &Platform,
     repository: &octocrab::models::Repository,
     asset: &octocrab::models::repos::Asset,
 ) -> anyhow::Result<PathBuf> {
+    let package_name = &package.name;
     let platform_dir = work_dir.join(format!("{target_platform}",));
     let recipe_dir = platform_dir.join(format!("{package_name}-{package_version}-{build_number}",));
     std::fs::create_dir_all(&recipe_dir).context("Failed to create recipe directory")?;
@@ -683,6 +684,25 @@ fn generate_rattler_build_recipe(
     let package_version = yaml_escape(package_version);
     let archive = yaml_escape(&archive);
 
+    let build_extra_section = if !package.expose.is_empty() {
+        let standard_dirs = ["bin", "etc", "extras", "include", "lib", "share", "ssl"];
+        let mut file_globs: Vec<String> = standard_dirs
+            .iter()
+            .map(|d| format!("      - {d}/**"))
+            .collect();
+        for dir in &package.expose {
+            file_globs.push(format!("      - {dir}/**"));
+        }
+        let files_section = format!("  files:\n    include:\n{}", file_globs.join("\n"));
+
+        let expose_val = package.expose.join("|");
+        let env_section = format!("  script:\n    env:\n      OCTOCONDA_EXPOSE: \"{expose_val}\"");
+
+        format!("{files_section}\n{env_section}")
+    } else {
+        String::new()
+    };
+
     let content = format!(
         r#"package:
   name: {pn}
@@ -698,6 +718,7 @@ build:
     binary_relocation: false
   prefix_detection:
     ignore: true
+{build_extra_section}
 
 tests:
   - package_contents:
@@ -729,7 +750,7 @@ fn generate_package(
 ) -> PackagingStatus {
     match generate_rattler_build_recipe(
         work_dir,
-        &package.name,
+        package,
         package_version,
         build_number,
         target_platform,


### PR DESCRIPTION
## Summary

- **Bundle mode**: New `bundle = true` config option that installs entire release trees under `$PREFIX/lib/<name>/` instead of flattening binaries into `$PREFIX/bin/`. Useful for complex applications like JDKs or `.app` bundles.
- **Expose globs**: New `expose` config option (list of glob patterns) that symlinks matched files from the bundle root into `$PREFIX/bin/`. On macOS, automatically tries `Home/<pattern>` and `MacOS/<pattern>` prefixes for cross-platform compatibility.
- **Custom tag prefix**: New `tag-prefix` config option to strip a custom prefix from release tags before version parsing (e.g., `tag-prefix = "jdk-"` for GraalVM's `jdk-25.0.2` tags).
- **Unified archive extraction**: Replaced individual `unzip`/`tar`/`gzip`/`xz`/`zstd`/`bzip2` handling in `build.sh` with `7zz` (7-Zip), reducing ~25 lines of case logic to 2 branches. Added `7zip` as a pixi dependency.
- **Improved platform regex**: Added `bin` as an allowed extra suffix in Linux, macOS, and Windows default platform patterns.
- **GraalVM CE config**: Added `graalvm/graalvm-ce-builds` as a bundle package in `config.toml` with `expose = ["bin/*"]`.
- **Tests**: Added tests for bundle+expose config parsing, expose-without-bundle rejection, custom tag prefix parsing, and tag prefix filtering.
