### PR TITLE
feat: Add Infisical/cli

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2433,6 +2433,11 @@ repository = "in-toto/witness"
 repository = "incu6us/goimports-reviser"
 
 [[packages]]
+repository = "Infisical/cli"
+name = "infisical"
+release-prefix = "cli"
+
+[[packages]]
 repository = "infracost/infracost"
 
 [[packages]]


### PR DESCRIPTION
Adds the [Infisical CLI](https://github.com/Infisical/cli) to `config.toml`.

```toml
[[packages]]
repository = "Infisical/cli"
name = "infisical"
release-prefix = "cli"
```

**Notes on the config:**
- Release assets are named `cli_<version>_<os>_<arch>.tar.gz`, so `name = "infisical"` avoids the package being named after the repo basename (`cli`).
- `release-prefix = "cli"` is required because each release also ships an `infisical-pkcs11_*.tar.gz` binary whose `_linux_amd64.tar.gz` / `_linux_arm64.tar.gz` suffixes otherwise match the default Linux patterns.

**Verification:**
- `octoconda` generates recipes for all 7 platforms (linux-32/64/aarch64, osx-64/arm64, win-64/arm64), each selecting only the `cli_*` asset.
- Built the linux-64 recipe locally with `rattler-build` (via `build-one`): build succeeded and the package test confirmed `bin/infisical` is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)