### PR TITLE
feat: Add Tigris CLI

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5577,6 +5577,12 @@ repository = "thomasschafer/scooter"
 repository = "thought-machine/please"
 
 [[packages]]
+repository = "tigrisdata/storage"
+name = "tigris-cli"
+release-prefix = "tigris"
+tag-prefix = "@tigrisdata/cli@"
+
+[[packages]]
 repository = "tilt-dev/ctlptl"
 
 [[packages]]


### PR DESCRIPTION
Adds Tigris CLI (tigris is a managed S3 object storage provider with forking capabilities).

Use the CLI package name (for clarity in case future additions), asset prefix picker, and monorepo tag prefix so Octoconda selects @tigrisdata/cli releases.