### PR TITLE
feat: Add Xata CLI

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5908,6 +5908,11 @@ repository = "x-motemen/gobump"
 repository = "XAMPPRocky/tokei"
 
 [[packages]]
+repository = "xataio/cli"
+name = "xata-cli"
+release-prefix = "xata"
+
+[[packages]]
 repository = "xataio/pgroll"
 
 [[packages]]


### PR DESCRIPTION
Xata is a postegresql with branching offering (either managed or self hosted).

- Add Xata CLI releases from `xataio/cli`.
- Package the CLI as `xata-cli` and match its `xata-...` release assets.