### PR TITLE
fix(secretspec): point linux-64 explicitly to bypass musl artifact

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -789,6 +789,7 @@ repository = "cackle-rs/cackle"
 
 [[packages]]
 repository = "cachix/secretspec"
+platforms = { linux-64 = "x86_64-unknown-linux-gnu\\.tar\\.xz$" }
 
 [[packages]]
 repository = "caddyserver/caddy"


### PR DESCRIPTION
As discusses in https://github.com/hunger/octoconda/issues/77 , the secretspec package was not working correctly as 0.17+ introduced a musl artifact that was detected first and thus made the linux-64 builds fail ... resulting in unavaibility..

This commit fix by explicitly adding regex to catch the correct one.